### PR TITLE
@ashetm/ng mediastream

### DIFF
--- a/projects/mediastream/CHANGELOG.md
+++ b/projects/mediastream/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.1
+
+- [x] Update README
+- [x] Update peer deps
+
 # 1.0.0
 
 * Write unit tests

--- a/projects/mediastream/README.md
+++ b/projects/mediastream/README.md
@@ -11,8 +11,15 @@
 <!-- [![Download Count](https://img.shields.io/npm/dm/ng-dialog.svg)](http://www.npmjs.com/package/ng-dialog) -->
 <!-- [![Code Climate](https://codeclimate.com/github/likeastore/ngDialog/badges/gpa.svg)](https://codeclimate.com/github/likeastore/ngDialog) -->
 
-
 <!-- ### [Demo](http://likeastore.github.io/ngDialog) -->
+
+## Compatibility Table
+
+| Angular Version                | @ashetm/ng-mediastream Version | Support |
+|--------------------------------|--------------------------------|---------|
+| Angular 16 and +               | Planned for later              | ✅      |
+| Angular >= 11.0.0 and < 16.0.0 | @ashetm/ng-mediastream 1.0.1   | ❌      |
+| Angular ~ 11.2.14              | @ashetm/ng-mediastream 1.0.0   | ❌      |
 
 ## Install
 

--- a/projects/mediastream/package.json
+++ b/projects/mediastream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ashetm/ng-mediastream",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "contributors": [
     {
       "email": "contact@ashetm.com",

--- a/projects/mediastream/package.json
+++ b/projects/mediastream/package.json
@@ -15,24 +15,27 @@
   },
   "keywords": [
     "angular",
-    "mediastream",
-    "js",
     "api",
+    "camera",
+    "js",
     "media",
-    "stream",
+    "mediastream",
+    "micro",
+    "microphone",
     "ng",
     "ng-service",
     "ng-services",
     "ng-mediastream",
-    "service"
+    "service",
+    "stream"
   ],
   "private": false,
   "repository": {
     "url": "https://github.com/AsheTM/ng-services/tree/main/projects/mediastream"
   },
   "peerDependencies": {
-    "@angular/common": "^11.2.14",
-    "@angular/core": "^11.2.14"
+    "@angular/common": ">=11.0.0 <16.0.0",
+    "@angular/core": ">=11.0.0 <16.0.0"
   },
   "dependencies": {
     "tslib": "^2.0.0"


### PR DESCRIPTION
# 1.0.1 
Restrict it to Angular versions between 11 included and 16 excluded
* Update README
* Update peer deps